### PR TITLE
ci: drop the pre-flight npm publish --dry-run from release-it

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -19,7 +19,7 @@
     "skipChecks": true
   },
   "hooks": {
-    "before:init": ["yarn build", "npm publish --dry-run"],
+    "before:init": ["yarn build"],
     "before:git:add": ["git add package.json CHANGELOG.md"],
     "after:release": "echo Successfully released ${name} v${version} to ${repo.repository}."
   },


### PR DESCRIPTION
`before:init` runs before release-it computes and writes the new version, so the dry-run always validated the version already sitting in package.json — which is by definition the one already on the registry.

It stayed quiet for three releases because an unauthenticated `npm publish --dry-run` only warns and exits zero. Node 24 (npm 11, whose dry-run does hit the registry) together with trusted publishing finally gave it an identity, and the release job now fails with "You cannot publish over the previously published versions: 5.1.7".

Nothing is lost by removing it: publint, arethetypeswrong and the smoke suite already run against the packed tarball in build-and-test, which the release job depends on through `needs`.

## Checks

- [ ] `yarn test` passes locally.
- [ ] Public API changes are reflected in the README.
