### PR TITLE
ci: exclude the generated CHANGELOG from oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -2,7 +2,9 @@
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
   "printWidth": 80,
   "singleQuote": true,
-  // .gitignore is honoured by default; .yarn/releases is committed, so it is
-  // the one thing that has to be excluded here
-  "ignorePatterns": [".yarn/**"]
+  // .gitignore is honoured by default, so only committed generated files need
+  // listing here: .yarn/releases, and CHANGELOG.md, which conventional-changelog
+  // writes with `*` bullets and a blank line this formatter would rewrite —
+  // every release would otherwise turn the next pull request red
+  "ignorePatterns": [".yarn/**", "CHANGELOG.md"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,9 @@ npx playwright test --project=chromium -g "should debounce"
   programmatically (dts plugins, api-extractor) needs `@typescript/typescript6` alongside it.
 - Yarn's builtin TypeScript compat patch breaks on TS 7 before 4.17 — keep the pinned Yarn
   release current.
+- **`CHANGELOG.md` is excluded from `oxfmt`.** conventional-changelog writes `*` bullets and an
+  extra blank line, which the formatter rewrites, so every release used to turn the next pull
+  request red. Leave it in `ignorePatterns` — the file is generated, not authored.
 - Do not commit `lib/` — it is gitignored and rebuilt on release.
 
 ## Release


### PR DESCRIPTION
## What is broken

Every pull request opened since the v6.0.0 release fails on the **Lint and check formatting** step, before anything else runs:

```
Checking formatting...

CHANGELOG.md (263ms)

Format issues found in above 1 files. Run without `--check` to fix.
##[error]Process completed with exit code 1.
```

That is the whole Renovate queue — nine red checks, none of them caused by the dependency bumps themselves.

## Why

`release-it` regenerates `CHANGELOG.md` through the Angular conventional-changelog preset. Its output uses `*` bullets and leaves an extra blank line before the new version heading; `oxfmt` wants `-` bullets and a single blank line:

```diff
-
 # [6.0.0](https://github.com/eavam/use-debouncy/compare/v5.1.7...v6.0.0) (2026-07-26)

-* feat!: audit fixes, React 18+, story gallery tests, Vite build and trusted publishing (#1223)
+- feat!: audit fixes, React 18+, story gallery tests, Vite build and trusted publishing (#1223)
```

Reformatting the file by hand would fix nothing — the next release regenerates it and the next branch goes red again.

## The change

`CHANGELOG.md` joins `.yarn/**` in the `oxfmt` `ignorePatterns`. It is a generated, committed file, which is exactly the category that list exists for. Gotcha noted in `CLAUDE.md` so nobody removes it later.

## Verification

Run locally against the current `main`, with the fix applied:

| Pipeline step | Result |
| --- | --- |
| `yarn lint:check` | passes, 42 files instead of 43 |
| `yarn typecheck` | passes |
| `yarn build` | passes, 0.53 kB gzip |
| `playwright test --project=chromium` | 47 passed |
| `publint --strict` + `arethetypeswrong` | no problems |
| `smoke` (packed tarball, `node --test`) | 5 passed |

Without the fix, `yarn lint:check` on the same tree reproduces the CI failure exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)