### PR TITLE
chore: hold dependency updates for 7 days and refresh the Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "description": [
+    "Updates land in one batch a month: the schedule opens on the first five days of the month, and nothing younger than 7 days is offered at all.",
+    "Everything here is a dev dependency — nothing ships to consumers — so freshness is worth less than letting a bad release be pulled before it reaches main unattended. Seven days clears that window while still leaving a fix released mid-month eligible for the next one.",
+    "Security fixes bypass both settings: vulnerabilityAlerts defaults to no minimum age, no schedule and immediate PR creation."
+  ],
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchPackageNames": ["react", "react-dom"],
       "groupName": "react update",
-      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     },
     {
-      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }
   ],


### PR DESCRIPTION
Two changes to `renovate.json`, no behaviour change to the monthly cadence.

## Minimum release age

```json
"minimumReleaseAge": "7 days"
```

No release younger than 7 days is offered at all. Every dependency in this repository is a dev dependency — nothing reaches consumers of the package — so a slower cadence costs nothing, while `automerge` on minor/patch means an unattended bad release would otherwise land on `main` at the next scheduled window with no human in between. Seven days covers the window in which a compromised or broken npm release is typically yanked, and still leaves a fix published mid-month eligible when the schedule next opens — a longer hold would push it out by a full month.

Mechanics worth knowing, since they answer the obvious objections:

- `internalChecksFilter` defaults to `strict`, so Renovate does not even open the branch until the age is met. No pending PRs sitting around waiting on a timer.
- `vulnerabilityAlerts` ships defaults of `minimumReleaseAge: null`, `schedule: []` and `prCreation: "immediate"` — security fixes ignore both the age and the monthly window and arrive right away.

## Stale syntax

`config:base` was renamed to `config:recommended`, and `updateTypes` to `matchUpdateTypes`, several major versions back. Both still work only because Renovate silently migrates them on every run — this just says what we mean.

## Schedule

Left exactly as it was (`* * 1-5 * *` — the first five days of the month), and now documented in the config's `description` field so it does not read like a day-of-week cron typed into the wrong position. It is intentional.

## Verification

`renovate-config-validator` from `renovate@42.99.0`:

```
 INFO: Validating renovate.json
 INFO: Config validated successfully
```

## Not included

Discussed but deliberately left out of this PR: `osvVulnerabilityAlerts`, `abandonmentThreshold`, pinning GitHub Action digests, batching non-major updates into a single PR, and Merge Confidence filtering. Note that GitHub Dependabot alerts are currently disabled on this repository (`GET /repos/eavam/use-debouncy/vulnerability-alerts` → 404), which is what Renovate's `vulnerabilityAlerts` reads from — worth turning on separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)